### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/test/Ebanx/Command/Request/DirectTest.php
+++ b/test/Ebanx/Command/Request/DirectTest.php
@@ -201,7 +201,7 @@ class DirectTest extends TestCase
     public function testValidatePaymentTypeCode()
     {
         $this->setExpectedException('InvalidArgumentException', "The parameter 'payment.payment_type_code' was not supplied.");
-        $this->params['payment']['payment_type_code'] = NULL; // weird bug fix, undefined index payment_type_code
+        $this->params['payment']['payment_type_code'] = null; // weird bug fix, undefined index payment_type_code
         \Ebanx\Ebanx::doRequest($this->params);
     }
 


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!