### PR TITLE
Zipcode command: Fix wrong action name in comment

### DIFF
--- a/src/Ebanx/Command/Zipcode.php
+++ b/src/Ebanx/Command/Zipcode.php
@@ -32,7 +32,7 @@
 namespace Ebanx\Command;
 
 /**
- * Command for the 'token' action
+ * Command for the 'zipcode' action
  *
  * @author Gustavo Henrique Mascarenhas Machado gustavo@ebanx.com
  */


### PR DESCRIPTION
Minor change to fix wrong action name reference in comment.